### PR TITLE
FIXES node retrocompatibility bug Cannot read property subtle of undefined

### DIFF
--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -15,6 +15,9 @@ export default class CryptoDriver implements CryptoInterface {
     }
 
     if (!this.driver) {
+      if (typeof webcrypto === 'undefined') {
+        webcrypto = { configurable: false, enumerable: true, get() { return lazyRequire('internal/crypto/webcrypto').crypto; } };
+      }
       // @ts-ignore
       this.driver = webcrypto.subtle;
     }


### PR DESCRIPTION
In node 12 to 15, the library doesn´t work because this error. I love the project! And if I see new issues, I try to fix them 👍